### PR TITLE
Removed reference to unexistant module

### DIFF
--- a/tests/testPrinceton.py
+++ b/tests/testPrinceton.py
@@ -1,5 +1,4 @@
-from pyspec.ccd.PrincetonSPE import PrincetonSPEFile
-import princeton
+from pyspec.ccd.files import PrincetonSPEFile
 import time
 import numpy as np
 import pylab
@@ -8,14 +7,6 @@ def test():
     t1 = time.time()
     conIm = PrincetonSPEFile('testimage2.spe')
     conIm = conIm.getData().astype(np.float32)
-    t2 = time.time()
-    print "Read took %.3f msec" % ((t2 - t1) * 1000)
-
-    pylab.figure()
-    pylab.imshow(conIm.sum(0))
-
-    t1 = time.time()
-    conIm = princeton.readSPE('testimage2.spe').astype(np.float32)
     t2 = time.time()
     print "Read took %.3f msec" % ((t2 - t1) * 1000)
 


### PR DESCRIPTION
Hi,

I had forked your project about one year ago when it was not on Github. I can't wait to contribute to this project.

For now, this is a small correction for a reference to an unexistant module (princeton). And there is a file rename too pyspec.ccd.PrincetonSPE -> pyspec.ccd.files

I'll summit other things soon.

Regards,
