### PR TITLE
Use extensions when dataline starts with '@'

### DIFF
--- a/pyspec/spec.py
+++ b/pyspec/spec.py
@@ -625,7 +625,10 @@ class SpecScan:
                         self.data = datum
                     else:
                         self.data = vstack((self.data, datum))
-
+            elif line[0] == '@':
+                # External data format, try using the extensions
+                for ext in specfile.userExtensions:
+                    ext.parseSpecScanDataLine(self, line)
             elif line[0:2] == '#C':
                 self.comments = self.comments + line
             else:


### PR DESCRIPTION
I'm a phd student at Ghent University in Belgium. We use pyspec in software that we developed here to plot and analyse pole figures that we measure at the National Synchrotron Lightsource at Brookhaven National Lab, NY, USA. There, we us a linear detector with 640 pixels. The readout of this detector (640 count values, one for every pixel) are stored in the spec file for every scan on one line that begins with the '@' character. An example of such a scan inside a spec file is visible below:
# L Phi  Chi  H  K  L  Epoch  Seconds  Detector  Ion 2  Ring  Threshold  SCA1  SCA2  Monitor  Center

-5 0 0.681437 0.059618 0 12 1 0 503574 286.17 819697 0 0 51375 4788

@A 1 4241 4293 4322 4450 4244 4120 4206 4084 4167 4205 4057 4166 4203 4225 4221 4225 4036 4123 4220 3970 4123 3981 4141 4003 3949 3764 3836 3977 3779 3821 3737 3736 3704 3587 3555 3383 3446 3430 3329 3459 3269 3214 3250 3103 3081 2974 3143 2984 2986 2992 2836 2783 2769 2820 2702 2586 2638 2621 2589 2517 2491 2473 2503 2382 2386 2329 2226 2254 2221 2212 2192 2084 2072 2011 2075 2024 1953 1991 1911 1892 1877 1942 1861 1869 1803 1805 1768 1735 1648 1831 1775 1700 1706 1716 1613 1663 1590 1703 1688 1650 1627 1647 1674 1667 1666 1671 1720 1821 1734 1915 1950 2003 2175 2216 2340 2478 2800 2966 3178 3317 3532 3792 3931 4148 4064 4127 4023 3999 3982 3718 3414 3345 3013 2787 2565 2440 2214 2129 2043 1894 1840 1704 1604 1568 1493 1470 1501 1429 1421 1390 1385 1263 1311 1310 1196 1196 1213 1210 1165 1145 1106 1197 1155 1104 1108 1062 1076 1044 1095 1091 1055 1019 1010 1042 982 988 1007 953 1019 946 978 1026 952 1000 879 933 978 962 959 915 997 949 948 961 928 965 923 953 941 880 889 866 925 903 926 878 870 894 897 929 938 940 933 979 998 953 970 965 971 995 974 1044 1011 945 984 978 1027 1016 991 1065 1075 1103 1177 1218 1298 1330 1467 1658 1851 2118 2418 2914 3344 3895 4235 4760 4944 5032 4824 4617 4368 3973 3515 3012 2569 2082 1830 1712 1452 1321 1267 1091 993 1041 957 906 842 864 846 843 835 802 821 768 730 711 717 667 743 703 736 719 720 750 677 670 670 671 649 663 687 662 650 682 593 634 653 666 665 646 608 654 663 595 609 646 647 619 654 636 587 660 633 613 628 631 537 563 589 618 638 595 617 604 609 603 544 584 573 626 604 639 620 591 598 630 565 558 570 602 622 573 577 570 611 577 568 616 555 573 623 562 567 569 611 566 585 525 570 557 572 587 597 585 568 579 580 553 585 558 543 592 567 526 560 532 597 583 597 549 566 584 595 558 632 589 535 579 549 563 555 552 572 563 563 539 573 559 553 562 560 518 625 551 523 583 583 598 556 558 572 556 613 570 632 559 590 577 577 552 591 586 632 650 621 645 614 641 631 613 661 674 686 704 765 756 778 789 772 836 860 957 972 1005 1019 1104 1130 1124 1185 1228 1194 1135 1073 1082 946 946 837 761 713 709 683 603 588 639 583 603 551 541 544 564 557 562 599 568 544 520 540 502 550 546 573 526 528 605 525 576 555 561 555 568 508 575 554 510 597 507 527 499 503 520 533 516 519 574 590 551 550 534 540 536 568 534 522 540 567 557 519 580 576 542 586 557 577 501 569 551 549 547 546 536 556 559 610 601 599 581 585 578 557 533 532 577 606 596 556 610 561 548 616 492 566 560 599 604 539 585 563 586 546 576 640 590 559 595 589 602 570 623 584 585 583 578 544 621 592 614 579 555 585 618 584 616 590 606 619 567 609 603 573 599 619 601 695 594 645 593 616 638 607 642 642 580 654 593 682 653 601 557 589 644 640 640 616 637 614 630 662 615 593 672 683 631 608 645 605 668 638 675 630 670 651 632 661 657 721 666 649 682 718 

My commit makes it possible for an extension to intervene when a line that starts with '@' is encountered in the file. Please consider to merge this into the project.

Best regards,
Bob De Schutter
